### PR TITLE
define site <base> for output

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,6 +20,7 @@ if (!current_user_can('edit_theme_options')) {
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width">
+	<base href="<?php echo get_site_url(); ?>" target="_blank">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 	<!--[if lt IE 9]>


### PR DESCRIPTION
adding the base URL for the setup, derived from WP site URL, so that posts may use relative linking for anchor hrefs, (e.g. using href="/index.php?page_id=837" to link to a specific page by ID)