### PR TITLE
modify play button SVG graphic appearance

### DIFF
--- a/style.css
+++ b/style.css
@@ -2155,6 +2155,15 @@ a.post-thumbnail:focus {
     position: relative;
 }
 
+/*
+ * 12.1.3 Media players
+ */
+ 
+.wp-video .mejs-overlay-button {
+    -webkit-filter: brightness(35%);
+    filter: brightness(35%);
+}
+
 /**
  * 12.2 Post Formats
  */


### PR DESCRIPTION
using CSS to change the color (brightness) of the SVG "bigplay.svg" included in WordPress, used as the play button overlay on videos. original white color was hard to see against light-colored video content.